### PR TITLE
Add events

### DIFF
--- a/src/interfaces/IEvents.sol
+++ b/src/interfaces/IEvents.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+pragma solidity ^0.8.28;
+
+interface IEvents {
+    // CollateralVaultFactory
+    event T_SetVaultManager(address indexed vaultManager);
+    event T_SetBeacon(address indexed targetVault, address indexed beacon);
+    event T_SetCollateralVaultLiquidated(address indexed collateralVault, address indexed liquidator);
+    event T_FactoryPause(bool pause);
+    event T_CollateralVaultCreated(address indexed vault);
+    // CollateralVaultBase
+    event T_Borrow(uint targetAmount, address indexed receiver);
+    event T_Repay(uint repayAmount);
+    event T_Deposit(uint amount);
+    event T_DepositUnderlying(uint amount);
+    event T_Withdraw(uint amount, address indexed receiver);
+    event T_RedeemUnderlying(uint amount, address indexed receiver);
+    event T_SetTwyneLiqLTV(uint ltv);
+    event T_Rebalance();
+    // EulerCollateralVault
+    event T_CollateralVaultInitialized();
+    event T_ControllerDisabled();
+    event T_HandleExternalLiquidation();
+    event T_Teleport(uint toDeposit, uint toReserve, uint toBorrow);
+    // VaultManager
+    event T_SetOracleRouter(address indexed newOracleRouter);
+    event T_SetIntermediateVault(address indexed intermediateVault);
+    event T_AddAllowedTargetVault(address indexed intermediateVault, address indexed targetVault);
+    event T_RemoveAllowedTargetVault(address indexed intermediateVault, address indexed targetVault, uint index);
+    event T_SetMaxLiqLTV(address indexed collateralAddress, uint16 ltv);
+    event T_SetExternalLiqBuffer(address indexed collateralAddress, uint16 liqBuffer);
+    event T_SetCollateralVaultFactory(address indexed factory);
+    event T_SetLTV(address indexed intermediateVault, address indexed collateralVault, uint16 borrowLimit, uint16 liquidationLimit, uint32 rampDuration);
+    event T_SetOracleResolvedVault(address indexed collateralAddress, bool allow);
+    event T_DoCall(address indexed to, uint value, bytes data);
+}

--- a/src/twyne/CollateralVaultBase.sol
+++ b/src/twyne/CollateralVaultBase.sol
@@ -165,6 +165,7 @@ abstract contract CollateralVaultBase is VaultBase {
         createVaultSnapshot();
         _borrow(_targetAmount, _receiver);
         evc.requireAccountAndVaultStatusCheck(address(this));
+        emit T_Borrow(_targetAmount, _receiver);
     }
 
     /// @notice Repays debt owed to the external lending protocol
@@ -185,6 +186,7 @@ abstract contract CollateralVaultBase is VaultBase {
 
         _repay(_amount);
         evc.requireVaultStatusCheck();
+        emit T_Repay(_amount);
     }
 
     ///
@@ -241,6 +243,7 @@ abstract contract CollateralVaultBase is VaultBase {
         totalAssetsDepositedOrReserved += assets;
         _handleExcessCredit();
         evc.requireAccountAndVaultStatusCheck(address(this));
+        emit T_Deposit(assets);
     }
 
     /// @notice Deposits a certain amount of underlying asset for a receiver.
@@ -255,6 +258,7 @@ abstract contract CollateralVaultBase is VaultBase {
         totalAssetsDepositedOrReserved += _depositUnderlying(underlying);
         _handleExcessCredit();
         evc.requireAccountAndVaultStatusCheck(address(this));
+        emit T_DepositUnderlying(underlying);
     }
 
     // _depositUnderlying() requires custom implementation per protocol integration
@@ -279,6 +283,7 @@ abstract contract CollateralVaultBase is VaultBase {
         SafeERC20.safeTransfer(IERC20(asset()), receiver, assets);
         _handleExcessCredit();
         evc.requireAccountAndVaultStatusCheck(address(this));
+        emit T_Withdraw(assets, receiver);
     }
 
     /// @notice Withdraw a certain amount of collateral and transfers collateral asset's underlying asset to receiver.
@@ -296,6 +301,7 @@ abstract contract CollateralVaultBase is VaultBase {
         _handleExcessCredit();
 
         evc.requireAccountAndVaultStatusCheck(address(this));
+        emit T_RedeemUnderlying(assets, receiver);
     }
 
     ///
@@ -308,6 +314,7 @@ abstract contract CollateralVaultBase is VaultBase {
         twyneVaultManager.checkLiqLTV(_ltv, targetVault, _asset);
         twyneLiqLTV = _ltv;
         evc.requireAccountAndVaultStatusCheck(address(this));
+        emit T_SetTwyneLiqLTV(_ltv);
     }
 
     /// @notice check if a vault can be liquidated
@@ -382,6 +389,7 @@ abstract contract CollateralVaultBase is VaultBase {
     function rebalance() external callThroughEVC nonReentrant {
         require(totalAssetsDepositedOrReserved <= IERC20(asset()).balanceOf(address(this)), ExternallyLiquidated());
         _handleExcessCredit();
+        emit T_Rebalance();
     }
 
     function teleport(uint toDeposit, uint toReserve, uint toBorrow) external virtual;

--- a/src/twyne/EulerCollateralVault.sol
+++ b/src/twyne/EulerCollateralVault.sol
@@ -43,6 +43,7 @@ contract EulerCollateralVault is CollateralVaultBase {
         eulerEVC.enableCollateral(address(this), address(__asset));
         eulerEVC.enableController(address(this), targetVault);
         SafeERC20.forceApprove(IERC20(targetAsset), targetVault, type(uint).max);
+        emit T_CollateralVaultInitialized();
     }
 
     /// @notice Disables the controller.
@@ -50,6 +51,7 @@ contract EulerCollateralVault is CollateralVaultBase {
     /// @dev required by IVault inheritance of VaultBase
     function disableController() external override callThroughEVC nonReentrant {
         evc.disableController(_msgSender());
+        emit T_ControllerDisabled();
     }
 
     /// @dev increment the version for proxy upgrades
@@ -226,6 +228,7 @@ contract EulerCollateralVault is CollateralVaultBase {
         delete borrower;
 
         evc.requireVaultStatusCheck();
+        emit T_HandleExternalLiquidation();
     }
 
     /// @notice allow users of the underlying protocol to seamlessly transfer their position to this vault
@@ -256,5 +259,6 @@ contract EulerCollateralVault is CollateralVaultBase {
         eulerEVC.batch(items);
 
         evc.requireAccountAndVaultStatusCheck(address(this));
+        emit T_Teleport(toDeposit, toReserve, toBorrow);
     }
 }

--- a/src/twyne/VaultBase.sol
+++ b/src/twyne/VaultBase.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.28;
 import {ReentrancyGuardUpgradeable} from "openzeppelin-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
 import {EVCUtil} from "ethereum-vault-connector/utils/EVCUtil.sol";
 import {IErrors} from "src/interfaces/IErrors.sol";
+import {IEvents} from "src/interfaces/IEvents.sol";
 import {IVault} from "ethereum-vault-connector/interfaces/IVault.sol";
 
 /// @title VaultBase
@@ -13,7 +14,7 @@ import {IVault} from "ethereum-vault-connector/interfaces/IVault.sol";
 /// It declares functions that must be defined in the child contract in order to
 /// correctly implement the controller release, vault status snapshotting and account/vaults
 /// status checks.
-abstract contract VaultBase is EVCUtil, ReentrancyGuardUpgradeable, IErrors, IVault {
+abstract contract VaultBase is EVCUtil, ReentrancyGuardUpgradeable, IErrors, IEvents, IVault {
     uint private snapshot;
     uint[50] private __gap;
 


### PR DESCRIPTION
Note: `CollateralVaultBase.liquidate()` does not need an event because it calls `CollateralVaultFactory.setCollateralVaultLiquidated()` which has an event